### PR TITLE
Fix tests and add package metadata

### DIFF
--- a/src/Microsoft.VisualStudio.Validation.Tests/App.config
+++ b/src/Microsoft.VisualStudio.Validation.Tests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="xunit.shadowCopy" value="false"/>
+  </appSettings>
+</configuration>

--- a/src/Microsoft.VisualStudio.Validation/Microsoft.VisualStudio.Validation.csproj
+++ b/src/Microsoft.VisualStudio.Validation/Microsoft.VisualStudio.Validation.csproj
@@ -4,12 +4,15 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>Microsoft.VisualStudio.Validation.ruleset</CodeAnalysisRuleSet>
     <RootNamespace>Microsoft</RootNamespace>
+
     <Description>Common input validation and state verification utility methods.</Description>
     <PackageTags>InputValidation IntegrityCheck</PackageTags>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
+    <PackageProjectUrl>https://github.com/Microsoft/vs-validation</PackageProjectUrl>
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <PackageIconUrl>https://aka.ms/VsExtensibilityIcon</PackageIconUrl>
     <Copyright>Copyright © Microsoft</Copyright>
     <DebugType>full</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
Inspired by @sharwell's https://github.com/Microsoft/vs-threading/pull/104, this makes tests "just work" in Test Explorer with skip verification and environment variables.