### PR TITLE
Fix Report.IfNotPresent for portable platforms

### DIFF
--- a/src/Microsoft.VisualStudio.Validation/Report.cs
+++ b/src/Microsoft.VisualStudio.Validation/Report.cs
@@ -35,10 +35,10 @@ namespace Microsoft
                 Type coreType = PrivateErrorHelpers.TrimGenericWrapper(typeof(T), typeof(Lazy<>));
 #if NET45       // TODO: we should remove this entire CPS-specific behavior.
                 if (Environment.GetEnvironmentVariable("CPSUnitTest") != "true")
+#endif
                 {
                     Fail(Strings.ServiceMissing, coreType.FullName);
                 }
-#endif
             }
         }
 


### PR DESCRIPTION
An #if region was too broad and basically made the method a no-op except on NET45.
Tests missed it because netcoreapp1.0 does not have TraceListeners so it can't actually be verified. The net452 tests of course verified correct behavior because it tested the NET45 compiled library.