### PR TITLE
Add some .netstandard 2.1 attributions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.2.300"
+    "version": "3.0.100-preview8-013437"
   }
 }

--- a/src/Microsoft.VisualStudio.Validation.sln
+++ b/src/Microsoft.VisualStudio.Validation.sln
@@ -1,16 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29216.181
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.Validation", "Microsoft.VisualStudio.Validation\Microsoft.VisualStudio.Validation.csproj", "{4D36901F-A937-4A2F-B086-CB2CD4DFB3FB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Validation", "Microsoft.VisualStudio.Validation\Microsoft.VisualStudio.Validation.csproj", "{4D36901F-A937-4A2F-B086-CB2CD4DFB3FB}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{871C5DB2-2E11-428A-A9FA-78E269B6E9B0}"
 	ProjectSection(SolutionItems) = preProject
-		..\appveyor.yml = ..\appveyor.yml
+		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
-		nuget.config = nuget.config
-		version.json = version.json
+		Directory.Build.targets = Directory.Build.targets
+		..\global.json = ..\global.json
+		..\nuget.config = ..\nuget.config
+		stylecop.json = stylecop.json
+		..\version.json = ..\version.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Validation.Tests", "Microsoft.VisualStudio.Validation.Tests\Microsoft.VisualStudio.Validation.Tests.csproj", "{B68F4565-AC94-4533-A9D6-5701F67D9C85}"
@@ -52,5 +55,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1AFE11BB-B1CE-40D5-AA63-E80706C7682C}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.VisualStudio.Validation/Assumes.cs
+++ b/src/Microsoft.VisualStudio.Validation/Assumes.cs
@@ -10,6 +10,7 @@ namespace Microsoft
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Runtime;
@@ -93,7 +94,7 @@ namespace Microsoft
         /// </summary>
         [DebuggerStepThrough]
         [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
-        public static void False(bool condition, [Localizable(false)] string message = null)
+        public static void False([DoesNotReturnIf(true)] bool condition, [Localizable(false)] string message = null)
         {
             if (condition)
             {
@@ -106,7 +107,7 @@ namespace Microsoft
         /// </summary>
         [DebuggerStepThrough]
         [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
-        public static void False(bool condition, [Localizable(false)] string unformattedMessage, object arg1)
+        public static void False([DoesNotReturnIf(true)] bool condition, [Localizable(false)] string unformattedMessage, object arg1)
         {
             if (condition)
             {
@@ -119,7 +120,7 @@ namespace Microsoft
         /// </summary>
         [DebuggerStepThrough]
         [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
-        public static void False(bool condition, [Localizable(false)] string unformattedMessage, params object[] args)
+        public static void False([DoesNotReturnIf(true)] bool condition, [Localizable(false)] string unformattedMessage, params object[] args)
         {
             if (condition)
             {
@@ -132,7 +133,7 @@ namespace Microsoft
         /// </summary>
         [DebuggerStepThrough]
         [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
-        public static void True(bool condition, [Localizable(false)] string message = null)
+        public static void True([DoesNotReturnIf(false)] bool condition, [Localizable(false)] string message = null)
         {
             if (!condition)
             {
@@ -145,7 +146,7 @@ namespace Microsoft
         /// </summary>
         [DebuggerStepThrough]
         [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
-        public static void True(bool condition, [Localizable(false)] string unformattedMessage, object arg1)
+        public static void True([DoesNotReturnIf(false)] bool condition, [Localizable(false)] string unformattedMessage, object arg1)
         {
             if (!condition)
             {
@@ -158,7 +159,7 @@ namespace Microsoft
         /// </summary>
         [DebuggerStepThrough]
         [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
-        public static void True(bool condition, [Localizable(false)] string unformattedMessage, params object[] args)
+        public static void True([DoesNotReturnIf(false)] bool condition, [Localizable(false)] string unformattedMessage, params object[] args)
         {
             if (!condition)
             {
@@ -170,6 +171,7 @@ namespace Microsoft
         /// Throws an public exception.
         /// </summary>
         [DebuggerStepThrough]
+        [DoesNotReturn]
         public static Exception NotReachable()
         {
             // Keep these two as separate lines of code, so the debugger can come in during the assert dialog
@@ -208,6 +210,7 @@ namespace Microsoft
         [DebuggerStepThrough]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Fail(string) instead.")]
+        [DoesNotReturn]
         public static Exception Fail([Localizable(false)] string message = null, bool showAssert = true) => Fail(message);
 
         /// <summary>
@@ -216,6 +219,7 @@ namespace Microsoft
         /// <returns>Nothing, as this method always throws.  The signature allows for "throwing" Fail so C# knows execution will stop.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Fail(string, Exception) instead.")]
+        [DoesNotReturn]
         public static Exception Fail([Localizable(false)] string message, Exception innerException, bool showAssert = true) => Fail(message, innerException);
 
         /// <summary>
@@ -223,6 +227,7 @@ namespace Microsoft
         /// </summary>
         /// <returns>Nothing, as this method always throws.  The signature allows for "throwing" Fail so C# knows execution will stop.</returns>
         [DebuggerStepThrough]
+        [DoesNotReturn]
         public static Exception Fail([Localizable(false)] string message = null)
         {
             var exception = new InternalErrorException(message);
@@ -241,6 +246,7 @@ namespace Microsoft
         /// Throws an public exception.
         /// </summary>
         /// <returns>Nothing, as this method always throws.  The signature allows for "throwing" Fail so C# knows execution will stop.</returns>
+        [DoesNotReturn]
         public static Exception Fail([Localizable(false)] string message, Exception innerException)
         {
             var exception = new InternalErrorException(message, innerException);

--- a/src/Microsoft.VisualStudio.Validation/DoesNotReturnAttribute.cs
+++ b/src/Microsoft.VisualStudio.Validation/DoesNotReturnAttribute.cs
@@ -1,0 +1,18 @@
+﻿/********************************************************
+*                                                        *
+*   © Copyright (C) Microsoft. All rights reserved.      *
+*                                                        *
+*********************************************************/
+
+#if NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
+}
+
+#endif

--- a/src/Microsoft.VisualStudio.Validation/DoesNotReturnIfAttribute.cs
+++ b/src/Microsoft.VisualStudio.Validation/DoesNotReturnIfAttribute.cs
@@ -1,0 +1,32 @@
+﻿/********************************************************
+*                                                        *
+*   © Copyright (C) Microsoft. All rights reserved.      *
+*                                                        *
+*********************************************************/
+
+#if NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies that the method will not return if the associated Boolean parameter is passed the specified value.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DoesNotReturnIfAttribute"/> class.
+        /// </summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => this.ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1623:Property summary documentation should match accessors", Justification = "Comment taken as-is from corefx.")]
+        public bool ParameterValue { get; }
+    }
+}
+
+#endif

--- a/src/Microsoft.VisualStudio.Validation/Microsoft.VisualStudio.Validation.csproj
+++ b/src/Microsoft.VisualStudio.Validation/Microsoft.VisualStudio.Validation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\shipping.ruleset</CodeAnalysisRuleSet>
     <RootNamespace>Microsoft</RootNamespace>

--- a/src/Microsoft.VisualStudio.Validation/Requires.cs
+++ b/src/Microsoft.VisualStudio.Validation/Requires.cs
@@ -8,9 +8,8 @@ namespace Microsoft
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Diagnostics;
-    using System.Globalization;
+    using System.Diagnostics.CodeAnalysis;
     using System.Runtime;
     using System.Threading.Tasks;
 
@@ -278,7 +277,7 @@ namespace Microsoft
         /// Throws an <see cref="ArgumentOutOfRangeException"/> if a condition does not evaluate to true.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Range(bool condition, string parameterName, string message = null)
+        public static void Range([DoesNotReturnIf(false)] bool condition, string parameterName, string message = null)
         {
             if (!condition)
             {
@@ -291,6 +290,7 @@ namespace Microsoft
         /// </summary>
         /// <returns>Nothing.  This method always throws.</returns>
         [DebuggerStepThrough]
+        [DoesNotReturn]
         public static Exception FailRange(string parameterName, string message = null)
         {
             if (string.IsNullOrEmpty(message))
@@ -307,7 +307,7 @@ namespace Microsoft
         /// Throws an ArgumentException if a condition does not evaluate to true.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Argument(bool condition, string parameterName, string message)
+        public static void Argument([DoesNotReturnIf(false)] bool condition, string parameterName, string message)
         {
             if (!condition)
             {
@@ -319,7 +319,7 @@ namespace Microsoft
         /// Throws an ArgumentException if a condition does not evaluate to true.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Argument(bool condition, string parameterName, string message, object arg1)
+        public static void Argument([DoesNotReturnIf(false)] bool condition, string parameterName, string message, object arg1)
         {
             if (!condition)
             {
@@ -331,7 +331,7 @@ namespace Microsoft
         /// Throws an ArgumentException if a condition does not evaluate to true.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Argument(bool condition, string parameterName, string message, object arg1, object arg2)
+        public static void Argument([DoesNotReturnIf(false)] bool condition, string parameterName, string message, object arg1, object arg2)
         {
             if (!condition)
             {
@@ -343,7 +343,7 @@ namespace Microsoft
         /// Throws an ArgumentException if a condition does not evaluate to true.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Argument(bool condition, string parameterName, string message, params object[] args)
+        public static void Argument([DoesNotReturnIf(false)] bool condition, string parameterName, string message, params object[] args)
         {
             if (!condition)
             {
@@ -356,6 +356,7 @@ namespace Microsoft
         /// </summary>
         /// <returns>Nothing.  It always throws.</returns>
         [DebuggerStepThrough]
+        [DoesNotReturn]
         public static Exception Fail(string message)
         {
             throw new ArgumentException(message);
@@ -366,6 +367,7 @@ namespace Microsoft
         /// </summary>
         /// <returns>Nothing.  It always throws.</returns>
         [DebuggerStepThrough]
+        [DoesNotReturn]
         public static Exception Fail(string unformattedMessage, params object[] args)
         {
             throw Fail(Format(unformattedMessage, args));
@@ -375,6 +377,7 @@ namespace Microsoft
         /// Throws an ArgumentException.
         /// </summary>
         [DebuggerStepThrough]
+        [DoesNotReturn]
         public static Exception Fail(Exception innerException, string unformattedMessage, params object[] args)
         {
             throw new ArgumentException(Format(unformattedMessage, args), innerException);

--- a/src/Microsoft.VisualStudio.Validation/Verify.cs
+++ b/src/Microsoft.VisualStudio.Validation/Verify.cs
@@ -9,6 +9,7 @@ namespace Microsoft
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Runtime.InteropServices;
@@ -22,7 +23,7 @@ namespace Microsoft
         /// Throws an <see cref="InvalidOperationException"/> if a condition is false.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Operation(bool condition, string message)
+        public static void Operation([DoesNotReturnIf(false)] bool condition, string message)
         {
             if (!condition)
             {
@@ -34,7 +35,7 @@ namespace Microsoft
         /// Throws an <see cref="InvalidOperationException"/> if a condition is false.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Operation(bool condition, string unformattedMessage, object arg1)
+        public static void Operation([DoesNotReturnIf(false)]bool condition, string unformattedMessage, object arg1)
         {
             if (!condition)
             {
@@ -46,7 +47,7 @@ namespace Microsoft
         /// Throws an <see cref="InvalidOperationException"/> if a condition is false.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Operation(bool condition, string unformattedMessage, object arg1, object arg2)
+        public static void Operation([DoesNotReturnIf(false)]bool condition, string unformattedMessage, object arg1, object arg2)
         {
             if (!condition)
             {
@@ -58,7 +59,7 @@ namespace Microsoft
         /// Throws an <see cref="InvalidOperationException"/> if a condition is false.
         /// </summary>
         [DebuggerStepThrough]
-        public static void Operation(bool condition, string unformattedMessage, params object[] args)
+        public static void Operation([DoesNotReturnIf(false)]bool condition, string unformattedMessage, params object[] args)
         {
             if (!condition)
             {
@@ -70,7 +71,7 @@ namespace Microsoft
         /// Throws an <see cref="InvalidOperationException"/> if a condition is false.
         /// </summary>
         [DebuggerStepThrough]
-        public static void OperationWithHelp(bool condition, string message, string helpLink)
+        public static void OperationWithHelp([DoesNotReturnIf(false)]bool condition, string message, string helpLink)
         {
             if (!condition)
             {
@@ -91,6 +92,7 @@ namespace Microsoft
         /// to satisfy C# execution path constraints.
         /// </returns>
         [DebuggerStepThrough]
+        [DoesNotReturn]
         public static Exception FailOperation(string message, params object[] args)
         {
             throw new InvalidOperationException(PrivateErrorHelpers.Format(message, args));
@@ -122,7 +124,7 @@ namespace Microsoft
         /// Throws an <see cref="ObjectDisposedException"/> if a condition is false.
         /// </summary>
         [DebuggerStepThrough]
-        public static void NotDisposed(bool condition, object disposedValue, string message = null)
+        public static void NotDisposed([DoesNotReturnIf(false)] bool condition, object disposedValue, string message = null)
         {
             if (!condition)
             {
@@ -142,7 +144,7 @@ namespace Microsoft
         /// Throws an <see cref="ObjectDisposedException"/> if a condition is false.
         /// </summary>
         [DebuggerStepThrough]
-        public static void NotDisposed(bool condition, string message)
+        public static void NotDisposed([DoesNotReturnIf(false)]bool condition, string message)
         {
             if (!condition)
             {


### PR DESCRIPTION
This allows C# 8 to produce better warnings around calls to these classes.

#31 suggested we add attributes. This does everything we can to help support nullable ref types in C# 8, but it's not particularly satisfying since `Requires.NotNull` itself doesn't get recognized by C#.