### PR TITLE
Fix argument exception messages and parameter names

### DIFF
--- a/src/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
+++ b/src/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
@@ -136,7 +136,8 @@ public class RequiresTests
         Assert.Throws<ArgumentNullException>(() => Requires.NotNullOrWhiteSpace(null, "paramName"));
         Assert.Throws<ArgumentException>(() => Requires.NotNullOrWhiteSpace(string.Empty, "paramName"));
         Assert.Throws<ArgumentException>(() => Requires.NotNullOrWhiteSpace("\0", "paramName"));
-        Assert.Throws<ArgumentException>(() => Requires.NotNullOrWhiteSpace(" \t\n\r ", "paramName"));
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => Requires.NotNullOrWhiteSpace(" \t\n\r ", "paramName"));
+        Assert.Equal("paramName", ex.ParamName);
     }
 
     [Fact]

--- a/src/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
+++ b/src/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
@@ -87,15 +87,8 @@ public class RequiresTests
     [Fact]
     public void Fail_Exception_ObjectArray()
     {
-        try
-        {
-            Requires.Fail(new InvalidOperationException(), "message", "arg1");
-            Assert.False(true, "Expected exception not thrown.");
-        }
-        catch (ArgumentException ex)
-        {
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
-        }
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => Requires.Fail(new InvalidOperationException(), "message", "arg1"));
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
     }
 
     [Fact]

--- a/src/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
+++ b/src/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
@@ -41,7 +41,6 @@ public class VerifyTests
         Verify.NotDisposed(true, "message");
         Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, "message"));
         Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, null));
-        Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, (object)null));
 
         try
         {
@@ -63,6 +62,17 @@ public class VerifyTests
         catch (ObjectDisposedException ex)
         {
             Assert.Equal(typeof(object).FullName, ex.ObjectName);
+        }
+
+        try
+        {
+            Verify.NotDisposed(false, "message");
+            Assert.False(true, "Expected exception not thrown.");
+        }
+        catch (ObjectDisposedException ex)
+        {
+            Assert.Null(ex.ObjectName);
+            Assert.Equal("message", ex.Message);
         }
     }
 

--- a/src/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
+++ b/src/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
@@ -71,7 +71,7 @@ public class VerifyTests
         }
         catch (ObjectDisposedException ex)
         {
-            Assert.Null(ex.ObjectName);
+            Assert.Equal(string.Empty, ex.ObjectName);
             Assert.Equal("message", ex.Message);
         }
     }

--- a/src/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
+++ b/src/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
@@ -23,16 +23,9 @@ public class VerifyTests
     public void OperationWithHelp()
     {
         Verify.OperationWithHelp(true, "message", "helpLink");
-        try
-        {
-            Verify.OperationWithHelp(false, "message", "helpLink");
-            Assert.True(false, "Expected exception not thrown");
-        }
-        catch (InvalidOperationException ex)
-        {
-            Assert.Equal("message", ex.Message);
-            Assert.Equal("helpLink", ex.HelpLink);
-        }
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => Verify.OperationWithHelp(false, "message", "helpLink"));
+        Assert.Equal("message", ex.Message);
+        Assert.Equal("helpLink", ex.HelpLink);
     }
 
     [Fact]
@@ -46,27 +39,13 @@ public class VerifyTests
         Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, null));
         Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, (object)null));
 
-        try
-        {
-            Verify.NotDisposed(false, "hi", "message");
-            Assert.False(true, "Expected exception not thrown.");
-        }
-        catch (ObjectDisposedException ex)
-        {
-            string expectedObjectName = typeof(string).FullName;
-            Assert.Equal(expectedObjectName, ex.ObjectName);
-            Assert.Equal(new ObjectDisposedException(expectedObjectName, "message").Message, ex.Message);
-        }
+        actualException = Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, "hi", "message"));
+        string expectedObjectName = typeof(string).FullName;
+        Assert.Equal(expectedObjectName, actualException.ObjectName);
+        Assert.Equal(new ObjectDisposedException(expectedObjectName, "message").Message, actualException.Message);
 
-        try
-        {
-            Verify.NotDisposed(false, new object());
-            Assert.False(true, "Expected exception not thrown.");
-        }
-        catch (ObjectDisposedException ex)
-        {
-            Assert.Equal(typeof(object).FullName, ex.ObjectName);
-        }
+        actualException = Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, new object()));
+        Assert.Equal(typeof(object).FullName, actualException.ObjectName);
     }
 
     [Fact]

--- a/src/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
+++ b/src/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
@@ -39,8 +39,12 @@ public class VerifyTests
     public void NotDisposed()
     {
         Verify.NotDisposed(true, "message");
-        Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, "message"));
+        ObjectDisposedException actualException = Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, "message"));
+        Assert.Equal(string.Empty, actualException.ObjectName);
+        Assert.Equal("message", actualException.Message);
+
         Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, null));
+        Assert.Throws<ObjectDisposedException>(() => Verify.NotDisposed(false, (object)null));
 
         try
         {
@@ -62,17 +66,6 @@ public class VerifyTests
         catch (ObjectDisposedException ex)
         {
             Assert.Equal(typeof(object).FullName, ex.ObjectName);
-        }
-
-        try
-        {
-            Verify.NotDisposed(false, "message");
-            Assert.False(true, "Expected exception not thrown.");
-        }
-        catch (ObjectDisposedException ex)
-        {
-            Assert.Equal(string.Empty, ex.ObjectName);
-            Assert.Equal("message", ex.Message);
         }
     }
 

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.cs.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.cs.xlf
@@ -19,8 +19,9 @@
           <target state="translated">Objekt {0} nesmí obsahovat element null (Nothing v jazyce Visual Basic).</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">Parametr {0} nemůže sestávat jen z prázdných znaků.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">Parametr {0} nemůže sestávat jen z prázdných znaků.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.de.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.de.xlf
@@ -19,8 +19,9 @@
           <target state="translated">"{0}" darf kein NULL-Element ("Nothing" in Visual Basic) enthalten.</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">Der Parameter "{0}" darf nicht nur aus Leerzeichen bestehen.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">Der Parameter "{0}" darf nicht nur aus Leerzeichen bestehen.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.es.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.es.xlf
@@ -19,8 +19,9 @@
           <target state="translated">'{0}' no puede contener un elemento null (Nothing en Visual Basic).</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">El parámetro "{0}" no puede constar solo de espacios en blanco.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">El parámetro "{0}" no puede constar solo de espacios en blanco.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.fr.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.fr.xlf
@@ -19,8 +19,9 @@
           <target state="translated">'{0}' ne peut pas contenir d'élément Null (Nothing en Visual Basic).</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">Le paramètre "{0}" ne peut pas être composé uniquement d'espaces blancs.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">Le paramètre "{0}" ne peut pas être composé uniquement d'espaces blancs.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.it.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.it.xlf
@@ -19,8 +19,9 @@
           <target state="translated">'{0}' non può contenere un elemento Null (Nothing in Visual Basic).</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">Il parametro "{0}" non può essere interamente costituito da spazi vuoti.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">Il parametro "{0}" non può essere interamente costituito da spazi vuoti.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.ja.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.ja.xlf
@@ -19,8 +19,9 @@
           <target state="translated">'{0}' には、null (Visual Basic では Nothing) 要素を含めることはできません。</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">パラメーター "{0}" は、すべて空白文字で構成することはできません。</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">パラメーター "{0}" は、すべて空白文字で構成することはできません。</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.ko.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.ko.xlf
@@ -19,8 +19,9 @@
           <target state="translated">'{0}에 null(Visual Basic에서는 Nothing) 요소를 포함할 수 없습니다.</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">"{0}" 매개 변수는 공백 문자로만 구성될 수 없습니다.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">"{0}" 매개 변수는 공백 문자로만 구성될 수 없습니다.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.pl.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.pl.xlf
@@ -19,8 +19,9 @@
           <target state="translated">Element „{0}” nie może zawierać elementu null (Nothing w języku Visual Basic).</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">Parametr „{0}” nie może składać się w całości ze znaków spacji.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">Parametr „{0}” nie może składać się w całości ze znaków spacji.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.pt-BR.xlf
@@ -19,8 +19,9 @@
           <target state="translated">'{0}' não pode conter um elemento nulo (Nada no Visual Basic).</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">O parâmetro "{0}" não pode consistir inteiramente em caracteres de espaço em branco.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">O parâmetro "{0}" não pode consistir inteiramente em caracteres de espaço em branco.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.ru.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.ru.xlf
@@ -19,8 +19,9 @@
           <target state="translated">"{0}" не может содержать элемент NULL (Nothing в Visual Basic).</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">Параметр "{0}" не может состоять только из пробелов.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">Параметр "{0}" не может состоять только из пробелов.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.tr.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.tr.xlf
@@ -19,8 +19,9 @@
           <target state="translated">'{0}' null (Visual Basic'te Hiçbir Şey) öğe içeremez.</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">"{0}" parametresi tamamen boşluk karakterlerinden oluşamaz.</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">"{0}" parametresi tamamen boşluk karakterlerinden oluşamaz.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.zh-Hans.xlf
@@ -19,8 +19,9 @@
           <target state="translated">“{0}”不能包含 null (Visual Basic 中为 Nothing)元素。</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">参数“{0}”不能全部由空白字符组成。</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">参数“{0}”不能全部由空白字符组成。</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Validation/MultilingualResources/Microsoft.VisualStudio.Validation.Desktop.zh-Hant.xlf
@@ -19,8 +19,9 @@
           <target state="translated">'{0}' 不能包含 null (在 Visual Basic 中為 Nothing) 項目。</target>
         </trans-unit>
         <trans-unit id="Argument_Whitespace" translate="yes" xml:space="preserve">
-          <source>The parameter "{0}" cannot consist entirely of white space characters.</source>
-          <target state="translated">參數 "{0}" 不可完全由空白字元構成。</target>
+          <source>The argument cannot consist entirely of white space characters.</source>
+          <target state="needs-review-translation">參數 "{0}" 不可完全由空白字元構成。</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InternalExceptionMessage" translate="yes" xml:space="preserve">
           <source>An internal error occurred. Please contact Microsoft Support.</source>

--- a/src/Microsoft.VisualStudio.Validation/Requires.cs
+++ b/src/Microsoft.VisualStudio.Validation/Requires.cs
@@ -169,7 +169,7 @@ namespace Microsoft
 
             if (string.IsNullOrWhiteSpace(value))
             {
-                throw new ArgumentException(Format(Strings.Argument_Whitespace, parameterName));
+                throw new ArgumentException(Format(Strings.Argument_Whitespace, parameterName), parameterName);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Validation/Requires.cs
+++ b/src/Microsoft.VisualStudio.Validation/Requires.cs
@@ -169,7 +169,7 @@ namespace Microsoft
 
             if (string.IsNullOrWhiteSpace(value))
             {
-                throw new ArgumentException(Format(Strings.Argument_Whitespace, parameterName), parameterName);
+                throw new ArgumentException(Strings.Argument_Whitespace, parameterName);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Validation/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Validation/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace Microsoft {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -40,7 +39,7 @@ namespace Microsoft {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -98,7 +97,7 @@ namespace Microsoft {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The parameter &quot;{0}&quot; cannot consist entirely of white space characters..
+        ///   Looks up a localized string similar to The argument cannot consist entirely of white space characters..
         /// </summary>
         internal static string Argument_Whitespace {
             get {

--- a/src/Microsoft.VisualStudio.Validation/Strings.resx
+++ b/src/Microsoft.VisualStudio.Validation/Strings.resx
@@ -130,7 +130,7 @@
     <value>'{0}' cannot contain a null (Nothing in Visual Basic) element.</value>
   </data>
   <data name="Argument_Whitespace" xml:space="preserve">
-    <value>The parameter "{0}" cannot consist entirely of white space characters.</value>
+    <value>The argument cannot consist entirely of white space characters.</value>
   </data>
   <data name="InternalExceptionMessage" xml:space="preserve">
     <value>An internal error occurred. Please contact Microsoft Support.</value>

--- a/src/Microsoft.VisualStudio.Validation/Verify.cs
+++ b/src/Microsoft.VisualStudio.Validation/Verify.cs
@@ -108,7 +108,7 @@ namespace Microsoft
 
             if (disposedValue.IsDisposed)
             {
-                string objectName = disposedValue != null ? disposedValue.GetType().FullName : string.Empty;
+                string objectName = disposedValue.GetType().FullName;
                 if (message != null)
                 {
                     throw new ObjectDisposedException(objectName, message);
@@ -126,9 +126,11 @@ namespace Microsoft
         [DebuggerStepThrough]
         public static void NotDisposed([DoesNotReturnIf(false)] bool condition, object disposedValue, string message = null)
         {
+            Requires.NotNull(disposedValue, nameof(disposedValue));
+
             if (!condition)
             {
-                string objectName = disposedValue != null ? disposedValue.GetType().FullName : string.Empty;
+                string objectName = disposedValue.GetType().FullName;
                 if (message != null)
                 {
                     throw new ObjectDisposedException(objectName, message);
@@ -148,7 +150,7 @@ namespace Microsoft
         {
             if (!condition)
             {
-                throw new ObjectDisposedException(message);
+                throw new ObjectDisposedException(null, message);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Validation/Verify.cs
+++ b/src/Microsoft.VisualStudio.Validation/Verify.cs
@@ -126,11 +126,9 @@ namespace Microsoft
         [DebuggerStepThrough]
         public static void NotDisposed([DoesNotReturnIf(false)] bool condition, object disposedValue, string message = null)
         {
-            Requires.NotNull(disposedValue, nameof(disposedValue));
-
             if (!condition)
             {
-                string objectName = disposedValue.GetType().FullName;
+                string objectName = disposedValue != null ? disposedValue.GetType().FullName : string.Empty;
                 if (message != null)
                 {
                     throw new ObjectDisposedException(objectName, message);


### PR DESCRIPTION
A couple of exceptions were thrown with missing parameter names or using the exception message as the object name. This fixes both.