### PR TITLE
Annotate Assumes.Is<T>(object) so C# knows the arg is non-null

### DIFF
--- a/src/Microsoft.VisualStudio.Validation/Assumes.cs
+++ b/src/Microsoft.VisualStudio.Validation/Assumes.cs
@@ -1,6 +1,6 @@
 /********************************************************
 *                                                        *
-*   © Copyright (C) Microsoft. All rights reserved.      *
+*   Â© Copyright (C) Microsoft. All rights reserved.      *
 *                                                        *
 *********************************************************/
 
@@ -84,7 +84,7 @@ namespace Microsoft
         /// <param name="value">The value to test.</param>
         [DebuggerStepThrough]
         [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
-        public static void Is<T>(object? value)
+        public static void Is<T>([NotNull] object? value)
         {
             True(value is T);
         }


### PR DESCRIPTION
Fixes #40