### PR TITLE
Remove netstandard2.1 target

### DIFF
--- a/src/Microsoft.VisualStudio.Validation/Microsoft.VisualStudio.Validation.csproj
+++ b/src/Microsoft.VisualStudio.Validation/Microsoft.VisualStudio.Validation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft</RootNamespace>
 
     <Description>Common input validation and state verification utility methods.</Description>


### PR DESCRIPTION
We don't have any `#if` directives in the source code nor conditioned build authoring, so this extra target was unnecessary.