### PR TITLE
Reduce allocations when checking for empty collections

### DIFF
--- a/src/Microsoft.VisualStudio.Validation/Assumes.cs
+++ b/src/Microsoft.VisualStudio.Validation/Assumes.cs
@@ -71,7 +71,23 @@ namespace Microsoft
         public static void NotNullOrEmpty<T>([ValidatedNotNull, NotNull]IEnumerable<T>? values)
         {
             Assumes.NotNull(values);
-            Assumes.True(values.Any());
+
+            bool isEmpty;
+            if (values is ICollection<T> collection)
+            {
+                isEmpty = collection.Count == 0;
+            }
+            else if (values is IReadOnlyCollection<T> readOnlyCollection)
+            {
+                isEmpty = readOnlyCollection.Count == 0;
+            }
+            else
+            {
+                using IEnumerator<T> enumerator = values.GetEnumerator();
+                isEmpty = !enumerator.MoveNext();
+            }
+
+            Assumes.False(isEmpty);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Validation/Requires.cs
+++ b/src/Microsoft.VisualStudio.Validation/Requires.cs
@@ -228,6 +228,31 @@ namespace Microsoft
 
         /// <summary>
         /// Throws an exception if the specified parameter's value is null,
+        /// has no elements.
+        /// </summary>
+        /// <typeparam name="T">The type of value in the collection.</typeparam>
+        /// <param name="values">The value of the argument.</param>
+        /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
+        /// <exception cref="ArgumentException">Thrown if the tested condition is false.</exception>
+        [DebuggerStepThrough]
+        public static void NotNullOrEmpty<T>([ValidatedNotNull, NotNull] ICollection<T> values, string? parameterName)
+        {
+            // To whoever is doing random code cleaning:
+            // Consider the performance when changing the code to delegate to NotNull.
+            // In general do not chain call to another function, check first and return as earlier as possible.
+            if (values is null)
+            {
+                throw new ArgumentNullException(parameterName);
+            }
+
+            if (values.Count == 0)
+            {
+                throw new ArgumentException(Format(Strings.Argument_EmptyArray, parameterName), parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an exception if the specified parameter's value is null,
         /// has no elements or has an element with a null value.
         /// </summary>
         /// <typeparam name="T">The type of the elements in the sequence.</typeparam>

--- a/src/Microsoft.VisualStudio.Validation/Requires.cs
+++ b/src/Microsoft.VisualStudio.Validation/Requires.cs
@@ -219,8 +219,22 @@ namespace Microsoft
                 throw new ArgumentNullException(parameterName);
             }
 
-            using IEnumerator<T> enumerator = values.GetEnumerator();
-            if (!enumerator.MoveNext())
+            bool isEmpty;
+            if (values is ICollection<T> collection)
+            {
+                isEmpty = collection.Count == 0;
+            }
+            else if (values is IReadOnlyCollection<T> readOnlyCollection)
+            {
+                isEmpty = readOnlyCollection.Count == 0;
+            }
+            else
+            {
+                using IEnumerator<T> enumerator = values.GetEnumerator();
+                isEmpty = !enumerator.MoveNext();
+            }
+
+            if (isEmpty)
             {
                 throw new ArgumentException(Format(Strings.Argument_EmptyArray, parameterName), parameterName);
             }

--- a/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
@@ -3,11 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft;
+using Moq;
 using Xunit;
 
 public partial class AssumesTests : IDisposable
@@ -88,6 +88,38 @@ public partial class AssumesTests : IDisposable
         Assert.ThrowsAny<Exception>(() => Assumes.NotNullOrEmpty((IEnumerable<string>?)null));
         Assert.ThrowsAny<Exception>(() => Assumes.NotNullOrEmpty(collection.Take(0)));
         Assumes.NotNullOrEmpty(collection.Take(1));
+    }
+
+    [Fact]
+    public void NotNullOrEmpty_EnumerableOfT_AlsoImplementsICollectionOfT()
+    {
+        // Mock type that implements both IEnumerable<T> and ICollection<T>
+        var collection = new Mock<ICollection<string>>(MockBehavior.Strict);
+        Mock<IEnumerable<string>> enumerable = collection.As<IEnumerable<string>>();
+
+        enumerable.Setup(m => m.GetEnumerator()).Throws(new Exception("Should not call GetEnumerator."));
+
+        collection.SetupGet(m => m.Count).Returns(0);
+        Assert.ThrowsAny<Exception>(() => Assumes.NotNullOrEmpty(enumerable.Object));
+
+        collection.SetupGet(m => m.Count).Returns(1);
+        Assumes.NotNullOrEmpty(enumerable.Object);
+    }
+
+    [Fact]
+    public void NotNullOrEmpty_EnumerableOfT_AlsoImplementsIReadOnlyCollectionOfT()
+    {
+        // Mock type that implements both IEnumerable<T> and IReadOnlyCollection<T>
+        var collection = new Mock<IReadOnlyCollection<string>>(MockBehavior.Strict);
+        Mock<IEnumerable<string>> enumerable = collection.As<IEnumerable<string>>();
+
+        enumerable.Setup(m => m.GetEnumerator()).Throws(new Exception("Should not call GetEnumerator."));
+
+        collection.SetupGet(m => m.Count).Returns(0);
+        Assert.ThrowsAny<Exception>(() => Assumes.NotNullOrEmpty(enumerable.Object));
+
+        collection.SetupGet(m => m.Count).Returns(1);
+        Assumes.NotNullOrEmpty(enumerable.Object);
     }
 
     [Fact]

--- a/test/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
@@ -164,7 +164,7 @@ public class RequiresTests
     }
 
     [Fact]
-    public void NotNullOrEmpty_Collection()
+    public void NotNullOrEmpty_Enumerable()
     {
         System.Collections.IEnumerable? nullCollection = null;
         System.Collections.IEnumerable emptyCollection = Array.Empty<string>();
@@ -175,7 +175,7 @@ public class RequiresTests
     }
 
     [Fact]
-    public void NotNullOrEmpty_CollectionOfT()
+    public void NotNullOrEmpty_EnumerableOfT_Class()
     {
         IEnumerable<string>? nullCollection = null;
         IEnumerable<string> emptyCollection = Array.Empty<string>();
@@ -186,11 +186,33 @@ public class RequiresTests
     }
 
     [Fact]
-    public void NotNullOrEmpty_CollectionOfT_Struct()
+    public void NotNullOrEmpty_EnumerableOfT_Struct()
     {
         IEnumerable<int>? nullCollection = null;
         IEnumerable<int> emptyCollection = Array.Empty<int>();
         IEnumerable<int> collection = new[] { 5 };
+        Requires.NotNullOrEmpty(collection, "param");
+        Assert.Throws<ArgumentNullException>(() => Requires.NotNullOrEmpty(nullCollection!, "param"));
+        Assert.Throws<ArgumentException>(() => Requires.NotNullOrEmpty(emptyCollection, "param"));
+    }
+
+    [Fact]
+    public void NotNullOrEmpty_CollectionOfT_Class()
+    {
+        ICollection<string>? nullCollection = null;
+        ICollection<string> emptyCollection = Array.Empty<string>();
+        ICollection<string> collection = new[] { "hi" };
+        Requires.NotNullOrEmpty(collection, "param");
+        Assert.Throws<ArgumentNullException>(() => Requires.NotNullOrEmpty(nullCollection!, "param"));
+        Assert.Throws<ArgumentException>(() => Requires.NotNullOrEmpty(emptyCollection, "param"));
+    }
+
+    [Fact]
+    public void NotNullOrEmpty_CollectionOfT_Struct()
+    {
+        ICollection<int>? nullCollection = null;
+        ICollection<int> emptyCollection = Array.Empty<int>();
+        ICollection<int> collection = new[] { 5 };
         Requires.NotNullOrEmpty(collection, "param");
         Assert.Throws<ArgumentNullException>(() => Requires.NotNullOrEmpty(nullCollection!, "param"));
         Assert.Throws<ArgumentException>(() => Requires.NotNullOrEmpty(emptyCollection, "param"));

--- a/test/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Microsoft;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -194,6 +195,38 @@ public class RequiresTests
         Requires.NotNullOrEmpty(collection, "param");
         Assert.Throws<ArgumentNullException>(() => Requires.NotNullOrEmpty(nullCollection!, "param"));
         Assert.Throws<ArgumentException>(() => Requires.NotNullOrEmpty(emptyCollection, "param"));
+    }
+
+    [Fact]
+    public void NotNullOrEmpty_EnumerableOfT_AlsoImplementsICollectionOfT()
+    {
+        // Mock type that implements both IEnumerable<T> and ICollection<T>
+        var collection = new Mock<ICollection<string>>(MockBehavior.Strict);
+        Mock<IEnumerable<string>> enumerable = collection.As<IEnumerable<string>>();
+
+        enumerable.Setup(m => m.GetEnumerator()).Throws(new Exception("Should not call GetEnumerator."));
+
+        collection.SetupGet(m => m.Count).Returns(0);
+        Assert.Throws<ArgumentException>(() => Requires.NotNullOrEmpty(enumerable.Object, "param"));
+
+        collection.SetupGet(m => m.Count).Returns(1);
+        Requires.NotNullOrEmpty(enumerable.Object, "param");
+    }
+
+    [Fact]
+    public void NotNullOrEmpty_EnumerableOfT_AlsoImplementsIReadOnlyCollectionOfT()
+    {
+        // Mock type that implements both IEnumerable<T> and IReadOnlyCollection<T>
+        var collection = new Mock<IReadOnlyCollection<string>>(MockBehavior.Strict);
+        Mock<IEnumerable<string>> enumerable = collection.As<IEnumerable<string>>();
+
+        enumerable.Setup(m => m.GetEnumerator()).Throws(new Exception("Should not call GetEnumerator."));
+
+        collection.SetupGet(m => m.Count).Returns(0);
+        Assert.Throws<ArgumentException>(() => Requires.NotNullOrEmpty(enumerable.Object, "param"));
+
+        collection.SetupGet(m => m.Count).Returns(1);
+        Requires.NotNullOrEmpty(enumerable.Object, "param");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #77.

Changes to reduce enumerator allocations via `NotNullOrEmpty` methods:

- Add overload of `Requires.NotNullOrEmpty` that accepts `ICollection<T>`
- Overloads that accepts `IEnumerable<T>` test for `ICollection<T>` and `IReadOnlyCollection<T>` to use `Count` if available
