### PR TITLE
Consume latest .NET SDK and other dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.7.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0-3.final" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
+    <AnalysisLevel>latest</AnalysisLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <UpdateXlfOnBuild Condition=" '$(UpdateXlfOnBuild)' == '' ">true</UpdateXlfOnBuild>
 
@@ -24,12 +25,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0-3.final" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.261" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/azure-pipelines/Convert-PDB.ps1
+++ b/azure-pipelines/Convert-PDB.ps1
@@ -18,7 +18,7 @@
         [string]$OutputPath
     )
 
-    $version = '1.1.0-beta2-20115-01'
+    $version = '1.1.0-beta2-21101-01'
     $baseDir = "$PSScriptRoot\..\obj\tools"
     $pdb2pdbpath = "$baseDir\Microsoft.DiaSymReader.Pdb2Pdb.$version\tools\Pdb2Pdb.exe"
     if (-not (Test-Path $pdb2pdbpath)) {

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -9,14 +9,14 @@ steps:
   displayName: dotnet test -f net472
   inputs:
     command: test
-    arguments: --no-build -c $(BuildConfiguration) -f net472 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
+    arguments: --no-build -c $(BuildConfiguration) -f net472 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_net472.binlog"
     testRunTitle: net472-$(Agent.JobName)
 
 - task: DotNetCoreCLI@2
   displayName: dotnet test -f netcoreapp2.1
   inputs:
     command: test
-    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
+    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_netcoreapp2.1.binlog"
     testRunTitle: netcoreapp2.1-$(Agent.JobName)
   condition: succeededOrFailed()
 
@@ -24,8 +24,16 @@ steps:
   displayName: dotnet test -f netcoreapp3.1
   inputs:
     command: test
-    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp3.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
+    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp3.1 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_netcoreapp3.1.binlog"
     testRunTitle: netcoreapp3.1-$(Agent.JobName)
+  condition: succeededOrFailed()
+
+- task: DotNetCoreCLI@2
+  displayName: dotnet test -f net5.0
+  inputs:
+    command: test
+    arguments: --no-build -c $(BuildConfiguration) -f net5.0 --filter "TestCategory!=FailsInCloudTest" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_net5.0.binlog"
+    testRunTitle: net5.0-$(Agent.JobName)
   condition: succeededOrFailed()
 
 - powershell: azure-pipelines/variables/_pipelines.ps1

--- a/azure-pipelines/publish-codecoverage.yml
+++ b/azure-pipelines/publish-codecoverage.yml
@@ -12,7 +12,7 @@ steps:
   displayName: Download macOS code coverage results
   continueOnError: true
 - powershell: |
-    dotnet tool install --tool-path obj dotnet-reportgenerator-globaltool --version 4.2.2 --configfile azure-pipelines/justnugetorg.nuget.config
+    dotnet tool install --tool-path obj dotnet-reportgenerator-globaltool --version 4.8.5 --configfile azure-pipelines/justnugetorg.nuget.config
     Copy-Item -Recurse $(Pipeline.Workspace)/coverageResults-Windows/obj/* $(System.DefaultWorkingDirectory)/obj
     Write-Host "Substituting {reporoot} with $(System.DefaultWorkingDirectory)"
     $reports = Get-ChildItem -Recurse "$(Pipeline.Workspace)/coverage.*.cobertura.xml"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.402",
-    "rollForward": "latestPatch",
+    "version": "5.0.102",
+    "rollForward": "patch",
     "allowPrerelease": false
   }
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, Directory.Build.props))\Directory.Build.props" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, Directory.Build.props))' != '' " />
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RootNamespace />

--- a/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
@@ -120,6 +120,7 @@ public partial class AssumesTests : IDisposable
         Assumes.Present("hi");
     }
 
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
     [Fact]
     public void InternalErrorException_IsSerializable()
     {
@@ -140,4 +141,5 @@ public partial class AssumesTests : IDisposable
             Assert.Equal(ex.Message, ex2.Message);
         }
     }
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
 }

--- a/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Debug.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Debug.cs
@@ -4,8 +4,7 @@
 // Ensure the tests defined in this file always emulate a client compiled for Debug
 #define DEBUG
 
-#if !NETCOREAPP2_1 // .NET Core < 3.0 doesn't let us use TraceListeners to verify behavior https://github.com/dotnet/corefx/issues/16596
-#if !NETCOREAPP3_1 // The tests fail in this environment too! :(
+#if NETFRAMEWORK // .NET Core doesn't let us use TraceListeners to verify behavior https://github.com/dotnet/corefx/issues/16596
 
 using System;
 using System.Diagnostics;
@@ -141,5 +140,4 @@ public class ReportDebugTests : IDisposable
             });
     }
 }
-#endif
 #endif


### PR DESCRIPTION
Update dotnet-reportgenerator-globaltool to 4.8.5
Propagate failure to install .NET SDK
Update analyzers
Add .NET 5.0 as a tested runtime
Update to .NET 5.0.102 SDK
Consume newer PDB conversion package that is signed