### PR TITLE
Interpolated string optimization

### DIFF
--- a/src/Microsoft.VisualStudio.Validation/Assumes.cs
+++ b/src/Microsoft.VisualStudio.Validation/Assumes.cs
@@ -163,6 +163,23 @@ public static partial class Assumes
         }
     }
 
+#if NET6_0_OR_GREATER
+
+    /// <summary>
+    /// Throws an public exception if a condition evaluates to true.
+    /// </summary>
+    [DebuggerStepThrough]
+    [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
+    public static void False([DoesNotReturnIf(true)] bool condition, [InterpolatedStringHandlerArgument("condition")] ref ValidationInterpolatedStringHandlerInvertedCondition message)
+    {
+        if (condition)
+        {
+            Fail(message.ToStringAndClear());
+        }
+    }
+
+#endif
+
     /// <summary>
     /// Throws an public exception if a condition evaluates to false.
     /// </summary>
@@ -201,6 +218,23 @@ public static partial class Assumes
             Fail(Format(unformattedMessage, args));
         }
     }
+
+#if NET6_0_OR_GREATER
+
+    /// <summary>
+    /// Throws an public exception if a condition evaluates to false.
+    /// </summary>
+    [DebuggerStepThrough]
+    [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
+    public static void True([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument("condition")] ref ValidationInterpolatedStringHandler message)
+    {
+        if (!condition)
+        {
+            Fail(message.ToStringAndClear());
+        }
+    }
+
+#endif
 
     /// <summary>
     /// Unconditionally throws an <see cref="InternalErrorException"/>.

--- a/src/Microsoft.VisualStudio.Validation/Assumes.cs
+++ b/src/Microsoft.VisualStudio.Validation/Assumes.cs
@@ -163,8 +163,6 @@ public static partial class Assumes
         }
     }
 
-#if NET6_0_OR_GREATER
-
     /// <summary>
     /// Throws an public exception if a condition evaluates to true.
     /// </summary>
@@ -177,8 +175,6 @@ public static partial class Assumes
             Fail(message.ToStringAndClear());
         }
     }
-
-#endif
 
     /// <summary>
     /// Throws an public exception if a condition evaluates to false.
@@ -219,8 +215,6 @@ public static partial class Assumes
         }
     }
 
-#if NET6_0_OR_GREATER
-
     /// <summary>
     /// Throws an public exception if a condition evaluates to false.
     /// </summary>
@@ -233,8 +227,6 @@ public static partial class Assumes
             Fail(message.ToStringAndClear());
         }
     }
-
-#endif
 
     /// <summary>
     /// Unconditionally throws an <see cref="InternalErrorException"/>.

--- a/src/Microsoft.VisualStudio.Validation/Polyfill.cs
+++ b/src/Microsoft.VisualStudio.Validation/Polyfill.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !NET5_0_OR_GREATER
+#if !NET6_0_OR_GREATER
 
+#pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
 #pragma warning disable SA1600 // Elements should be documented
 
@@ -14,6 +15,24 @@ namespace System.Runtime.CompilerServices
         internal CallerArgumentExpressionAttribute(string parameterName)
         {
         }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+    internal sealed class InterpolatedStringHandlerAttribute : Attribute
+    {
+        public InterpolatedStringHandlerAttribute()
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
+    {
+        public InterpolatedStringHandlerArgumentAttribute(string argument) => this.Arguments = new string[] { argument };
+
+        public InterpolatedStringHandlerArgumentAttribute(params string[] arguments) => this.Arguments = arguments;
+
+        public string[] Arguments { get; }
     }
 }
 

--- a/src/Microsoft.VisualStudio.Validation/Report.cs
+++ b/src/Microsoft.VisualStudio.Validation/Report.cs
@@ -7,6 +7,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft;
 
@@ -89,6 +90,22 @@ public static class Report
             Fail(PrivateErrorHelpers.Format(message, args));
         }
     }
+
+#if NET6_0_OR_GREATER
+
+    /// <summary>
+    /// Reports an error if a condition does not evaluate to true.
+    /// </summary>
+    [Conditional("DEBUG")]
+    public static void IfNot(bool condition, [InterpolatedStringHandlerArgument("condition")] ref ValidationInterpolatedStringHandler message)
+    {
+        if (!condition)
+        {
+            Fail(message.ToStringAndClear());
+        }
+    }
+
+#endif
 
     /// <summary>
     /// Reports a certain failure.

--- a/src/Microsoft.VisualStudio.Validation/Report.cs
+++ b/src/Microsoft.VisualStudio.Validation/Report.cs
@@ -91,8 +91,6 @@ public static class Report
         }
     }
 
-#if NET6_0_OR_GREATER
-
     /// <summary>
     /// Reports an error if a condition does not evaluate to true.
     /// </summary>
@@ -104,8 +102,6 @@ public static class Report
             Fail(message.ToStringAndClear());
         }
     }
-
-#endif
 
     /// <summary>
     /// Reports a certain failure.

--- a/src/Microsoft.VisualStudio.Validation/Requires.cs
+++ b/src/Microsoft.VisualStudio.Validation/Requires.cs
@@ -418,8 +418,6 @@ public static class Requires
         }
     }
 
-#if NET6_0_OR_GREATER
-
     /// <summary>
     /// Throws an <see cref="ArgumentException"/> if a condition does not evaluate to true.
     /// </summary>
@@ -431,8 +429,6 @@ public static class Requires
             throw new ArgumentException(message.ToStringAndClear(), parameterName);
         }
     }
-
-#endif
 
     /// <summary>
     /// Throws an <see cref="ArgumentException"/> if a condition does not evaluate to true.

--- a/src/Microsoft.VisualStudio.Validation/Requires.cs
+++ b/src/Microsoft.VisualStudio.Validation/Requires.cs
@@ -418,6 +418,22 @@ public static class Requires
         }
     }
 
+#if NET6_0_OR_GREATER
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException"/> if a condition does not evaluate to true.
+    /// </summary>
+    [DebuggerStepThrough]
+    public static void Argument([DoesNotReturnIf(false)] bool condition, string? parameterName, [InterpolatedStringHandlerArgument("condition")] ref ValidationInterpolatedStringHandler message)
+    {
+        if (!condition)
+        {
+            throw new ArgumentException(message.ToStringAndClear(), parameterName);
+        }
+    }
+
+#endif
+
     /// <summary>
     /// Throws an <see cref="ArgumentException"/> if a condition does not evaluate to true.
     /// </summary>

--- a/src/Microsoft.VisualStudio.Validation/ValidationInterpolatedStringHandler.cs
+++ b/src/Microsoft.VisualStudio.Validation/ValidationInterpolatedStringHandler.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET6_0_OR_GREATER
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Microsoft;
+
+/// <summary>Provides an interpolated string handler for validation functions that only perform formatting if the condition check fails.</summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[InterpolatedStringHandler]
+public ref struct ValidationInterpolatedStringHandler
+{
+    /// <summary>The handler we use to perform the formatting.</summary>
+    private StringBuilder.AppendInterpolatedStringHandler stringBuilderHandler;
+    private StringBuilder? stringBuilder;
+
+    /// <summary>Initializes a new instance of the <see cref="ValidationInterpolatedStringHandler"/> struct.</summary>
+    /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
+    /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+    /// <param name="condition">The condition Boolean passed to the <see cref="Debug"/> method.</param>
+    /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
+    /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+    public ValidationInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool shouldAppend)
+    {
+        if (condition)
+        {
+            shouldAppend = false;
+        }
+        else
+        {
+            // Only used when failing an assert.  Additional allocation here doesn't matter; just create a new StringBuilder.
+            this.stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount, this.stringBuilder = new StringBuilder());
+            shouldAppend = true;
+        }
+    }
+
+    /// <summary>Writes the specified string to the handler.</summary>
+    /// <param name="value">The string to write.</param>
+    public void AppendLiteral(string value) => this.stringBuilderHandler.AppendLiteral(value);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    public void AppendFormatted<T>(T value) => this.stringBuilderHandler.AppendFormatted(value);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <param name="format">The format string.</param>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    public void AppendFormatted<T>(T value, string? format) => this.stringBuilderHandler.AppendFormatted(value, format);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    public void AppendFormatted<T>(T value, int alignment) => this.stringBuilderHandler.AppendFormatted(value, alignment);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+    /// <param name="format">The format string.</param>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    public void AppendFormatted<T>(T value, int alignment, string? format) => this.stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+    /// <summary>Writes the specified character span to the handler.</summary>
+    /// <param name="value">The span to write.</param>
+    public void AppendFormatted(ReadOnlySpan<char> value) => this.stringBuilderHandler.AppendFormatted(value);
+
+    /// <summary>Writes the specified string of chars to the handler.</summary>
+    /// <param name="value">The span to write.</param>
+    /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+    /// <param name="format">The format string.</param>
+    public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => this.stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    public void AppendFormatted(string? value) => this.stringBuilderHandler.AppendFormatted(value);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+    /// <param name="format">The format string.</param>
+    public void AppendFormatted(string? value, int alignment = 0, string? format = null) => this.stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+    /// <param name="format">The format string.</param>
+    public void AppendFormatted(object? value, int alignment = 0, string? format = null) => this.stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+    /// <summary>Extracts the built string from the handler.</summary>
+    /// <returns>The formatted string.</returns>
+    internal string ToStringAndClear()
+    {
+        string s = this.stringBuilder?.ToString() ?? string.Empty;
+        this.stringBuilder = null;
+        this.stringBuilderHandler = default;
+        return s;
+    }
+}
+
+#endif

--- a/src/Microsoft.VisualStudio.Validation/ValidationInterpolatedStringHandler.cs
+++ b/src/Microsoft.VisualStudio.Validation/ValidationInterpolatedStringHandler.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET6_0_OR_GREATER
-
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -14,9 +12,12 @@ namespace Microsoft;
 [InterpolatedStringHandler]
 public ref struct ValidationInterpolatedStringHandler
 {
+    private StringBuilder? stringBuilder;
+
+#if NET6_0_OR_GREATER
     /// <summary>The handler we use to perform the formatting.</summary>
     private StringBuilder.AppendInterpolatedStringHandler stringBuilderHandler;
-    private StringBuilder? stringBuilder;
+#endif
 
     /// <summary>Initializes a new instance of the <see cref="ValidationInterpolatedStringHandler"/> struct.</summary>
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
@@ -33,10 +34,16 @@ public ref struct ValidationInterpolatedStringHandler
         else
         {
             // Only used when failing an assert.  Additional allocation here doesn't matter; just create a new StringBuilder.
+#if NET6_0_OR_GREATER
             this.stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount, this.stringBuilder = new StringBuilder());
+#else
+            this.stringBuilder = new();
+#endif
             shouldAppend = true;
         }
     }
+
+#if NET6_0_OR_GREATER
 
     /// <summary>Writes the specified string to the handler.</summary>
     /// <param name="value">The string to write.</param>
@@ -92,15 +99,47 @@ public ref struct ValidationInterpolatedStringHandler
     /// <param name="format">The format string.</param>
     public void AppendFormatted(object? value, int alignment = 0, string? format = null) => this.stringBuilderHandler.AppendFormatted(value, alignment, format);
 
+#else
+
+    /// <summary>Writes the specified string to the handler.</summary>
+    /// <param name="value">The string to write.</param>
+    public void AppendLiteral(string value) => this.stringBuilder!.Append(value);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    public void AppendFormatted<T>(T value) => this.stringBuilder!.Append(value);
+
+    /// <summary>Writes the specified value to the handler.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+    /// <param name="format">The format string.</param>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    public void AppendFormatted<T>(T value, int alignment = 0, string? format = null)
+    {
+        string result = value is IFormattable ? ((IFormattable)value).ToString(format, null) : (value?.ToString() ?? string.Empty);
+        bool left = alignment < 0;
+        alignment = Math.Abs(alignment);
+        if (result.Length < alignment)
+        {
+            string padding = new string(' ', alignment - result.Length);
+            result = left ? result + padding : padding + result;
+        }
+
+        this.stringBuilder!.Append(result);
+    }
+
+#endif
+
     /// <summary>Extracts the built string from the handler.</summary>
     /// <returns>The formatted string.</returns>
     internal string ToStringAndClear()
     {
         string s = this.stringBuilder?.ToString() ?? string.Empty;
         this.stringBuilder = null;
+#if NET6_0_OR_GREATER
         this.stringBuilderHandler = default;
+#endif
         return s;
     }
 }
-
-#endif

--- a/src/Microsoft.VisualStudio.Validation/ValidationInterpolatedStringHandlerInvertedCondition.cs
+++ b/src/Microsoft.VisualStudio.Validation/ValidationInterpolatedStringHandlerInvertedCondition.cs
@@ -12,21 +12,21 @@ namespace Microsoft;
 /// <summary>Provides an interpolated string handler for validation functions that only perform formatting if the condition check fails.</summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 [InterpolatedStringHandler]
-public ref struct ValidationInterpolatedStringHandler
+public ref struct ValidationInterpolatedStringHandlerInvertedCondition
 {
     /// <summary>The handler we use to perform the formatting.</summary>
     private StringBuilder.AppendInterpolatedStringHandler stringBuilderHandler;
     private StringBuilder? stringBuilder;
 
-    /// <summary>Initializes a new instance of the <see cref="ValidationInterpolatedStringHandler"/> struct.</summary>
+    /// <summary>Initializes a new instance of the <see cref="ValidationInterpolatedStringHandlerInvertedCondition"/> struct.</summary>
     /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
     /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
     /// <param name="condition">The condition Boolean passed to the method.</param>
     /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
     /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
-    public ValidationInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool shouldAppend)
+    public ValidationInterpolatedStringHandlerInvertedCondition(int literalLength, int formattedCount, bool condition, out bool shouldAppend)
     {
-        if (condition)
+        if (!condition)
         {
             shouldAppend = false;
         }

--- a/src/Microsoft.VisualStudio.Validation/Verify.cs
+++ b/src/Microsoft.VisualStudio.Validation/Verify.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Microsoft;
@@ -59,6 +60,22 @@ public static partial class Verify
             throw new InvalidOperationException(PrivateErrorHelpers.Format(unformattedMessage, args));
         }
     }
+
+#if NET6_0_OR_GREATER
+
+    /// <summary>
+    /// Throws an <see cref="InvalidOperationException"/> if a condition is false.
+    /// </summary>
+    [DebuggerStepThrough]
+    public static void Operation([DoesNotReturnIf(false)]bool condition, [InterpolatedStringHandlerArgument("condition")] ref ValidationInterpolatedStringHandler message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message.ToStringAndClear());
+        }
+    }
+
+#endif
 
     /// <summary>
     /// Throws an <see cref="InvalidOperationException"/> if a condition is false.

--- a/src/Microsoft.VisualStudio.Validation/Verify.cs
+++ b/src/Microsoft.VisualStudio.Validation/Verify.cs
@@ -103,6 +103,21 @@ public static partial class Verify
     /// </returns>
     [DebuggerStepThrough]
     [DoesNotReturn]
+    public static Exception FailOperation(string message)
+    {
+        throw new InvalidOperationException(message);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="InvalidOperationException"/>.
+    /// </summary>
+    /// <returns>
+    /// Nothing.  This method always throws.
+    /// The signature claims to return an exception to allow callers to throw this method
+    /// to satisfy C# execution path constraints.
+    /// </returns>
+    [DebuggerStepThrough]
+    [DoesNotReturn]
     public static Exception FailOperation(string message, params object?[] args)
     {
         throw new InvalidOperationException(PrivateErrorHelpers.Format(message, args));

--- a/src/Microsoft.VisualStudio.Validation/Verify.cs
+++ b/src/Microsoft.VisualStudio.Validation/Verify.cs
@@ -61,8 +61,6 @@ public static partial class Verify
         }
     }
 
-#if NET6_0_OR_GREATER
-
     /// <summary>
     /// Throws an <see cref="InvalidOperationException"/> if a condition is false.
     /// </summary>
@@ -74,8 +72,6 @@ public static partial class Verify
             throw new InvalidOperationException(message.ToStringAndClear());
         }
     }
-
-#endif
 
     /// <summary>
     /// Throws an <see cref="InvalidOperationException"/> if a condition is false.

--- a/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
@@ -34,6 +34,46 @@ public partial class AssumesTests : IDisposable
         Assert.ThrowsAny<Exception>(() => Assumes.False(true, TestMessage, "arg1", "arg2"));
     }
 
+#if NET6_0_OR_GREATER
+
+    [Fact]
+    public void True_InterpolatedString()
+    {
+        int formatCount = 0;
+        string FormattingMethod()
+        {
+            formatCount++;
+            return "generated string";
+        }
+
+        Assumes.True(true, $"Some {FormattingMethod()} method.");
+        Assert.Equal(0, formatCount);
+
+        Exception ex = Assert.ThrowsAny<Exception>(() => Assumes.True(false, $"Some {FormattingMethod()} method."));
+        Assert.Equal(1, formatCount);
+        Assert.StartsWith("Some generated string method.", ex.Message);
+    }
+
+    [Fact]
+    public void False_InterpolatedString()
+    {
+        int formatCount = 0;
+        string FormattingMethod()
+        {
+            formatCount++;
+            return "generated string";
+        }
+
+        Assumes.False(false, $"Some {FormattingMethod()} method.");
+        Assert.Equal(0, formatCount);
+
+        Exception ex = Assert.ThrowsAny<Exception>(() => Assumes.False(true, $"Some {FormattingMethod()} method."));
+        Assert.Equal(1, formatCount);
+        Assert.StartsWith("Some generated string method.", ex.Message);
+    }
+
+#endif
+
     [Fact]
     public void Fail()
     {

--- a/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
@@ -34,8 +34,6 @@ public partial class AssumesTests : IDisposable
         Assert.ThrowsAny<Exception>(() => Assumes.False(true, TestMessage, "arg1", "arg2"));
     }
 
-#if NET6_0_OR_GREATER
-
     [Fact]
     public void True_InterpolatedString()
     {
@@ -71,8 +69,6 @@ public partial class AssumesTests : IDisposable
         Assert.Equal(1, formatCount);
         Assert.StartsWith("Some generated string method.", ex.Message);
     }
-
-#endif
 
     [Fact]
     public void Fail()

--- a/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Debug.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Debug.cs
@@ -107,8 +107,6 @@ public class ReportDebugTests : IDisposable
         }
     }
 
-#if NET6_0_OR_GREATER
-
     [Fact]
     public void IfNot_InterpolatedString()
     {
@@ -124,13 +122,15 @@ public class ReportDebugTests : IDisposable
             Report.IfNot(true, $"a{FormattingMethod()}c");
             Assert.Equal(0, formatCount);
             listener.Value.Setup(l => l.WriteLine("abc")).Verifiable();
+#if NETCOREAPP
             listener.Value.Setup(l => l.Fail("abc", string.Empty)).Verifiable();
+#else
+            listener.Value.Setup(l => l.Fail("abc")).Verifiable();
+#endif
             Report.IfNot(false, $"a{FormattingMethod()}c");
             Assert.Equal(1, formatCount);
         }
     }
-
-#endif
 
     [Fact]
     public void IfNotPresent()

--- a/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Debug.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Debug.cs
@@ -107,6 +107,31 @@ public class ReportDebugTests : IDisposable
         }
     }
 
+#if NET6_0_OR_GREATER
+
+    [Fact]
+    public void IfNot_InterpolatedString()
+    {
+        int formatCount = 0;
+        string FormattingMethod()
+        {
+            formatCount++;
+            return "b";
+        }
+
+        using (DisposableValue<Mock<TraceListener>> listener = Listen())
+        {
+            Report.IfNot(true, $"a{FormattingMethod()}c");
+            Assert.Equal(0, formatCount);
+            listener.Value.Setup(l => l.WriteLine("abc")).Verifiable();
+            listener.Value.Setup(l => l.Fail("abc", string.Empty)).Verifiable();
+            Report.IfNot(false, $"a{FormattingMethod()}c");
+            Assert.Equal(1, formatCount);
+        }
+    }
+
+#endif
+
     [Fact]
     public void IfNotPresent()
     {

--- a/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Release.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Release.cs
@@ -76,8 +76,6 @@ public class ReportReleaseTests : IDisposable
         }
     }
 
-#if NET6_0_OR_GREATER
-
     [Fact]
     public void IfNot_InterpolatedString()
     {
@@ -96,8 +94,6 @@ public class ReportReleaseTests : IDisposable
             Assert.Equal(0, formatCount);
         }
     }
-
-#endif
 
     [Fact]
     public void IfNotPresent()

--- a/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Release.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/ReportTests.Release.cs
@@ -76,6 +76,29 @@ public class ReportReleaseTests : IDisposable
         }
     }
 
+#if NET6_0_OR_GREATER
+
+    [Fact]
+    public void IfNot_InterpolatedString()
+    {
+        int formatCount = 0;
+        string FormattingMethod()
+        {
+            formatCount++;
+            return "b";
+        }
+
+        using (DisposableValue<Mock<TraceListener>> listener = Listen())
+        {
+            Report.IfNot(true, $"a{FormattingMethod()}c");
+            Assert.Equal(0, formatCount);
+            Report.IfNot(false, $"a{FormattingMethod()}c");
+            Assert.Equal(0, formatCount);
+        }
+    }
+
+#endif
+
     [Fact]
     public void IfNotPresent()
     {

--- a/test/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
@@ -150,8 +150,6 @@ public class RequiresTests
         Assert.StartsWith(TestStrings.FormatSomeError3Args("arg1", "arg2", "arg3"), ex.Message);
     }
 
-#if NET6_0_OR_GREATER
-
     [Fact]
     public void Argument_InterpolatedString()
     {
@@ -169,8 +167,6 @@ public class RequiresTests
         Assert.Equal(1, formatCount);
         Assert.StartsWith("Some generated string method.", ex.Message);
     }
-
-#endif
 
     [Fact]
     public void Fail()

--- a/test/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/RequiresTests.cs
@@ -150,6 +150,28 @@ public class RequiresTests
         Assert.StartsWith(TestStrings.FormatSomeError3Args("arg1", "arg2", "arg3"), ex.Message);
     }
 
+#if NET6_0_OR_GREATER
+
+    [Fact]
+    public void Argument_InterpolatedString()
+    {
+        int formatCount = 0;
+        string FormattingMethod()
+        {
+            formatCount++;
+            return "generated string";
+        }
+
+        Requires.Argument(true, "paramName", $"Some {FormattingMethod()} method.");
+        Assert.Equal(0, formatCount);
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => Requires.Argument(false, "paramName", $"Some {FormattingMethod()} method."));
+        Assert.Equal(1, formatCount);
+        Assert.StartsWith("Some generated string method.", ex.Message);
+    }
+
+#endif
+
     [Fact]
     public void Fail()
     {

--- a/test/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
@@ -21,6 +21,28 @@ public class VerifyTests
         Assert.Throws<InvalidOperationException>(() => Verify.Operation(false, "throw", "arg1", "arg2", "arg3"));
     }
 
+#if NET6_0_OR_GREATER
+
+    [Fact]
+    public void Operation_InterpolatedString()
+    {
+        int formatCount = 0;
+        string FormattingMethod()
+        {
+            formatCount++;
+            return "generated string";
+        }
+
+        Verify.Operation(true, $"Some {FormattingMethod()} method.");
+        Assert.Equal(0, formatCount);
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => Verify.Operation(false, $"Some {FormattingMethod()} method."));
+        Assert.Equal(1, formatCount);
+        Assert.StartsWith("Some generated string method.", ex.Message);
+    }
+
+#endif
+
     [Fact]
     public void OperationWithHelp()
     {

--- a/test/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
@@ -83,9 +83,17 @@ public class VerifyTests
     }
 
     [Fact]
-    public void FailOperation()
+    public void FailOperation_ParamsFormattingArgs()
     {
-        Assert.Throws<InvalidOperationException>(() => Verify.FailOperation("message", "arg1"));
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => Verify.FailOperation("a{0}c", "b"));
+        Assert.Equal("abc", ex.Message);
+    }
+
+    [Fact]
+    public void FailOperation_String()
+    {
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => Verify.FailOperation("a{0}c"));
+        Assert.Equal("a{0}c", ex.Message);
     }
 
     [Fact]

--- a/test/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
@@ -21,8 +21,6 @@ public class VerifyTests
         Assert.Throws<InvalidOperationException>(() => Verify.Operation(false, "throw", "arg1", "arg2", "arg3"));
     }
 
-#if NET6_0_OR_GREATER
-
     [Fact]
     public void Operation_InterpolatedString()
     {
@@ -40,8 +38,6 @@ public class VerifyTests
         Assert.Equal(1, formatCount);
         Assert.StartsWith("Some generated string method.", ex.Message);
     }
-
-#endif
 
     [Fact]
     public void OperationWithHelp()

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.6",
+  "version": "17.8-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Optimizes methods on the `Requires`, `Assumes`, `Report` and `Verify` classes that take string formatting args to include an overload that has special handling for interpolated strings to avoid any string formatting or allocations when the condition will not lead to a thrown exception.

This will automatically make the following code alloc-free, for example:

```cs
Requires.Argument(true, $"Some {mighty} error.");
```

The nice thing about the above is it scales to any number of formatting arguments and types.

Prior to this change, something like this was alloc free because we had an overload to handle 1 or 2 formatting arguments:
```cs
Requires.Argument(true, $"Some {0} error.", "mighty");
```

But as soon as you go beyond 2 args, or one of the args is a value-type, allocations would be required even in the success case.
But when using interpolated strings, there is never an allocation in the success case.

**This optimization depends on the calling code targeting .NET 6 or better.** We could theoretically make it available to .NET Framework as well, but we'd have to copy at least [this large code file](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs) from .NET into this library.