### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.4",
+      "version": "7.3.6",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.3",
+      "version": "17.8.4",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,10 @@ indent_size = 2
 indent_size = 2
 indent_style = space
 
+[*.ps1]
+indent_style = space
+indent_size = 4
+
 # Dotnet code style settings:
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  ignore:
+    # This package has unlisted versions on nuget.org that are not supported. Avoid them.
+    - dependency-name: dotnet-format
+      versions: ["6.x", "7.x", "8.x"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   schedule:
     interval: weekly
   ignore:
-    # This package has unlisted versions on nuget.org that are not supported. Avoid them.
-    - dependency-name: dotnet-format
-      versions: ["6.x", "7.x", "8.x"]
+  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
+  - dependency-name: dotnet-format
+    versions: ["6.x", "7.x", "8.x"]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.3.5-beta1.23323.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <MicroBuildVersion>2.0.137</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.3.5-beta1.23323.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.3.5-beta1.23330.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Moq" Version="4.18.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,15 +4,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
-    <MicroBuildVersion>2.0.130</MicroBuildVersion>
+    <MicroBuildVersion>2.0.137</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.3.5-beta1.23323.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -32,7 +32,7 @@ jobs:
 
   - template: install-dependencies.yml
 
-  - script: dotnet tool run nbgv cloud -ca
+  - script: dotnet nbgv cloud -ca
     displayName: ⚙ Set build number
 
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -8,6 +8,7 @@ steps:
     outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
     outputformat: text
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  retryCountOnTaskFailure: 3 # fails when the cloud service is overloaded
 
 - task: MicroBuildSigningPlugin@4
   inputs:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,12 @@
 <Project>
+  <!-- Include and reference README in nuge package, if a README is in the project directory. -->
+  <PropertyGroup>
+    <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Condition="Exists('README.md')" Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>

--- a/src/Microsoft.VisualStudio.Validation/Microsoft.VisualStudio.Validation.csproj
+++ b/src/Microsoft.VisualStudio.Validation/Microsoft.VisualStudio.Validation.csproj
@@ -5,11 +5,7 @@
 
     <Description>Common input validation and state verification utility methods.</Description>
     <PackageTags>InputValidation IntegrityCheck</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-  <ItemGroup>
-    <None Include="$(RepoRootPath)README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Strings.resx" EmitFormatMethods="true" />
   </ItemGroup>


### PR DESCRIPTION
- Bump Microsoft.NET.Test.Sdk to 17.6.3
- Bump powershell to 7.3.5
- Automatically include a README.md from the project directory
- Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0 (#210)
- Bump MicroBuildVersion to 2.0.131
- Bump xunit from 2.4.2 to 2.5.0 (#209)
- Remove `tool run` from `dotnet nbgv` invocation
- Dependabot to ignore dotnet-format
- Set tab settings for .ps1 files
- Bump powershell from 7.3.5 to 7.3.6 (#212)
- Bump dotnet-coverage from 17.7.3 to 17.8.0 (#211)
- Bump dotnet-coverage to 17.8.2
- Bump MicroBuild version to 2.0.134
- Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 (#213)
- Bump Microbuild version to 2.0.137
- Tolerate NOTICE file task network failures
- Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 (#214)
- Bump dotnet-coverage from 17.8.2 to 17.8.4 (#215)
- Align YAML indentation more consistently
- Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 (#218)
- Bump Microsoft.CodeAnalysis.ResxSourceGenerator to 3.3.5-beta1.23330.2
