### PR TITLE
Include type name in Assumes.Null/NotNull failures

### DIFF
--- a/src/Microsoft.VisualStudio.Validation/Assumes.cs
+++ b/src/Microsoft.VisualStudio.Validation/Assumes.cs
@@ -4,7 +4,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 
@@ -24,7 +23,10 @@ public static partial class Assumes
     public static void NotNull<T>([ValidatedNotNull, NotNull]T? value)
         where T : class
     {
-        True(value is object);
+        if (value is null)
+        {
+            FailNotNull<T>();
+        }
     }
 
     /// <summary>
@@ -36,7 +38,10 @@ public static partial class Assumes
     public static void NotNull<T>([ValidatedNotNull, NotNull]T? value)
         where T : struct
     {
-        True(value.HasValue);
+        if (!value.HasValue)
+        {
+            FailNotNull<T>();
+        }
     }
 
     /// <summary>
@@ -97,7 +102,10 @@ public static partial class Assumes
     public static void Null<T>(T? value)
         where T : class
     {
-        True(value is null);
+        if (value is not null)
+        {
+            FailNull<T>();
+        }
     }
 
     /// <summary>
@@ -109,7 +117,10 @@ public static partial class Assumes
     public static void Null<T>(T? value)
         where T : struct
     {
-        False(value.HasValue);
+        if (value.HasValue)
+        {
+            FailNull<T>();
+        }
     }
 
     /// <summary>
@@ -354,6 +365,20 @@ public static partial class Assumes
             return new Exception();
 #pragma warning restore CS8763
         }
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void FailNotNull<T>()
+    {
+        Fail(Strings.FormatUnexpectedNull(typeof(T).Name));
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void FailNull<T>()
+    {
+        Fail(Strings.FormatUnexpectedNonNull(typeof(T).Name));
     }
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.Validation/Strings.resx
+++ b/src/Microsoft.VisualStudio.Validation/Strings.resx
@@ -144,4 +144,10 @@
   <data name="ServiceMissing" xml:space="preserve">
     <value>Cannot find an instance of the {0} service.</value>
   </data>
+  <data name="UnexpectedNull" xml:space="preserve">
+    <value>Unexpected null value of type '{0}'.</value>
+  </data>
+  <data name="UnexpectedNonNull" xml:space="preserve">
+    <value>Unexpected non-null value of type '{0}'.</value>
+  </data>
 </root>

--- a/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft;
 using Moq;
@@ -9,11 +10,13 @@ using Xunit;
 public partial class AssumesTests : IDisposable
 {
     private const string TestMessage = "Some test message.";
-    private AssertDialogSuppression suppressAssertUi = new AssertDialogSuppression();
+    private readonly AssertDialogSuppression suppressAssertUi = new();
+    private readonly OverrideCulture overrideCulture = new(CultureInfo.InvariantCulture);
 
     public void Dispose()
     {
         this.suppressAssertUi.Dispose();
+        this.overrideCulture.Dispose();
     }
 
     [Fact]

--- a/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/AssumesTests.cs
@@ -79,28 +79,40 @@ public partial class AssumesTests : IDisposable
     [Fact]
     public void NotNull()
     {
-        Assert.ThrowsAny<Exception>(() => Assumes.NotNull((object?)null));
+        Exception ex = Assert.ThrowsAny<Exception>(() => Assumes.NotNull((string?)null));
+
+        Assert.Equal("Unexpected null value of type 'String'.", ex.Message);
+
         Assumes.NotNull("success");
     }
 
     [Fact]
     public void NotNull_NullableStruct()
     {
-        Assert.ThrowsAny<Exception>(() => Assumes.NotNull((int?)null));
+        Exception ex = Assert.ThrowsAny<Exception>(() => Assumes.NotNull((int?)null));
+
+        Assert.Equal("Unexpected null value of type 'Int32'.", ex.Message);
+
         Assumes.NotNull((int?)5);
     }
 
     [Fact]
     public void Null()
     {
-        Assert.ThrowsAny<Exception>(() => Assumes.Null("not null"));
+        Exception ex = Assert.ThrowsAny<Exception>(() => Assumes.Null("not null"));
+
+        Assert.Equal("Unexpected non-null value of type 'String'.", ex.Message);
+
         Assumes.Null((object?)null);
     }
 
     [Fact]
     public void Null_NullableStruct()
     {
-        Assert.ThrowsAny<Exception>(() => Assumes.Null((int?)5));
+        Exception ex = Assert.ThrowsAny<Exception>(() => Assumes.Null((int?)5));
+
+        Assert.Equal("Unexpected non-null value of type 'Int32'.", ex.Message);
+
         Assumes.Null((int?)null);
     }
 

--- a/test/Microsoft.VisualStudio.Validation.Tests/OverrideCulture.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/OverrideCulture.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+/// <summary>
+/// Sets a specific culture for a duration, restoring the prior culture upon disposal.
+/// </summary>
+internal sealed class OverrideCulture : IDisposable
+{
+    private readonly CultureInfo priorCulture;
+    private readonly CultureInfo priorUICulture;
+
+    public OverrideCulture(CultureInfo culture)
+    {
+        this.priorCulture = CultureInfo.CurrentCulture;
+        this.priorUICulture = CultureInfo.CurrentUICulture;
+
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+    }
+
+    public void Dispose()
+    {
+        CultureInfo.CurrentCulture = this.priorCulture;
+        CultureInfo.CurrentUICulture = this.priorUICulture;
+    }
+}


### PR DESCRIPTION
Recently I've seen a few errors from customers with error text "value is null" (the caller's expression), which isn't particularly helpful. This change attempts to include the name of the type in the message, which will help with diagnosis in many cases. With this change the message would read something like "Unexpected null value of type 'String'.".

I've attempted to preserve the inlineability and tiny code size of the original methods by moving the formatting into a separate method. That method is generic (to avoid the caller having code to produce a type name) which could increase generated code size, however I wouldn't expect that to be a huge concern. It's worth calling out for review though.