### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,13 +9,13 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.0",
+      "version": "17.11.3",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.133",
+      "version": "3.6.139",
       "commands": [
         "nbgv"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,7 @@ indent_size = 2
 # Xml config files
 [*.{ruleset,config,nuspec,resx,vsixmanifest,vsct,runsettings}]
 indent_size = 2
+indent_style = space
 
 # JSON files
 [*.json]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,23 +56,4 @@
       <PackageReleaseNotes Condition="'$(PackageProjectUrl)'!=''">$(PackageProjectUrl)/releases/tag/v$(Version)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
-
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
-    <IsWpfTempProject>false</IsWpfTempProject>
-    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
-  </PropertyGroup>
-
-  <!--
-    Inspired by https://github.com/dotnet/arcade/blob/cbfa29d4e859622ada3d226f90f103f659665d31/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props#L14-L31
-
-    Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.
-    The project name is non-deterministic and is included in the Source Link json file name and xlf directory names.
-    It's also not necessary to generate these assets.
-  -->
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
-    <EnableSourceLink>false</EnableSourceLink>
-    <EmbedUntrackedSources>false</EmbedUntrackedSources>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->
-    <EmbedUntrackedSources Condition=" '$(UseWPF)' == 'true' ">false</EmbedUntrackedSources>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,21 +9,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.3.5-beta1.23330.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0" />
-    <PackageVersion Include="xunit" Version="2.8.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageVersion Include="xunit" Version="2.8.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-  </ItemGroup>
-  <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/Archive-SourceCode.ps1
+++ b/azure-pipelines/Archive-SourceCode.ps1
@@ -203,16 +203,25 @@ if ($PSCmdlet.ShouldProcess('source archival request', 'post')) {
 
     $Response = Invoke-WebRequest -Uri $SourceCodeArchivalUri -Method POST -Body $RequestJson -ContentType "application/json" -UseBasicParsing -SkipHttpErrorCheck
     Write-Host "Status Code : " -NoNewline
-    $responseContent = ConvertFrom-Json ($Response.Content)
     if ($Response.StatusCode -eq 200) {
         Write-Host $Response.StatusCode -ForegroundColor Green
         Write-Host "Ticket ID   : " -NoNewline
+        $responseContent = ConvertFrom-Json ($Response.Content)
         Write-Host $responseContent
     }
     else {
-        $responseContent = ConvertFrom-Json $Response.Content
         Write-Host $Response.StatusCode -ForegroundColor Red
-        Write-Host "Message     : $($responseContent.message)"
+        try {
+            $responseContent = ConvertFrom-Json $Response.Content
+            Write-Host "Message     : $($responseContent.message)"
+        }
+        catch {
+            Write-Host "JSON Parse Error: $($_.Exception.Message)"
+            Write-Host "Raw response content:"
+            Write-Host $Response.Content
+        }
+
+        exit 2
     }
 } elseif ($SourceCodeArchivalUri) {
     Write-Host "Would have posted to $SourceCodeArchivalUri"

--- a/azure-pipelines/OptProf.yml
+++ b/azure-pipelines/OptProf.yml
@@ -17,6 +17,12 @@ schedules:
 #    name: DeploymentScripts
 #    ref: refs/heads/test
 
+parameters:
+  - name: ShouldSkipOptimize
+    displayName: Skip OptProf optimization
+    type: boolean
+    default: false # Should usually be false so that optprof LKG can apply when tests fail, but may need to be set to true in a manually queued pipeline run if all drops have expired.
+
 variables:
 - template: GlobalVariables.yml
 - name: PublicRelease
@@ -37,7 +43,7 @@ stages:
       RealSign: true
       windowsPool: VSEngSS-MicroBuild2022-1ES
       EnableMacOSBuild: false
-      ShouldSkipOptimize: true
+      ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
       IsOptProf: true
       RunTests: false
 - stage: QueueVSBuild

--- a/azure-pipelines/WIFtoPATauth.yml
+++ b/azure-pipelines/WIFtoPATauth.yml
@@ -1,0 +1,22 @@
+parameters:
+- name: deadPATServiceConnectionId # The GUID of the PAT-based service connection whose access token must be replaced.
+  type: string
+- name: wifServiceConnectionName # The name of the WIF service connection to use to get the access token.
+  type: string
+- name: resource # The scope for which the access token is requested.
+  type: string
+  default: 499b84ac-1321-427f-aa17-267ca6975798 # Azure Artifact feeds (any of them)
+
+steps:
+- task: AzureCLI@2
+  displayName: 🔏 Authenticate with WIF service connection
+  inputs:
+    azureSubscription: ${{ parameters.wifServiceConnectionName }}
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      $accessToken = az account get-access-token --query accessToken --resource '${{ parameters.resource }}' -o tsv
+      # Set the access token as a secret, so it doesn't get leaked in the logs
+      Write-Host "##vso[task.setsecret]$accessToken"
+      # Override the apitoken of the nuget service connection, for the duration of this stage
+      Write-Host "##vso[task.setendpoint id=${{ parameters.deadPATServiceConnectionId }};field=authParameter;key=apitoken]$accessToken"

--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -1,5 +1,7 @@
 parameters:
 - name: initArgs
+  type: string
+  default: ''
 - name: needsAzurePublicFeeds
   type: boolean
   default: true # If nuget.config pulls from the azure-public account, we need to authenticate when building on the devdiv account.

--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -1,14 +1,21 @@
 parameters:
-  initArgs:
+- name: initArgs
+- name: needsAzurePublicFeeds
+  type: boolean
+  default: true # If nuget.config pulls from the azure-public account, we need to authenticate when building on the devdiv account.
 
 steps:
+- ${{ if and(parameters.needsAzurePublicFeeds, eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9')) }}:
+  - template: WIFtoPATauth.yml
+    parameters:
+      wifServiceConnectionName: azure-public/vside package pull
+      deadPATServiceConnectionId: 0ae39abc-4d06-4436-a7b5-865833df49db # azure-public/msft_consumption
 
 - task: NuGetAuthenticate@1
   displayName: 🔏 Authenticate NuGet feeds
   inputs:
-    ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
-      nuGetServiceConnections: azure-public/msft_consumption # Only necessary for GitHub-hosted repos
-    forceReinstallCredentialProvider: true
+    ${{ if and(parameters.needsAzurePublicFeeds, eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9')) }}:
+      nuGetServiceConnections: azure-public/msft_consumption
 
 - powershell: |
     $AccessToken = '$(System.AccessToken)' # Avoid specifying the access token directly on the init.ps1 command line to avoid it showing up in errors

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -27,10 +27,10 @@ parameters:
 # As an entrypoint pipeline yml file, all parameters here show up in the Queue Run dialog.
 # If any paramaters should NOT be queue-time options, they should be removed from here
 # and references to them in this file replaced with hard-coded values.
-- name: RealSign
-  displayName: Real sign?
+- name: ForceOfficialBuild
+  displayName: Official build (sign, compliance, etc.)
   type: boolean
-  default: false
+  default: false # this should remain false so PR builds using this pipeline are unofficial
 # - name: ShouldSkipOptimize # Uncomment this and references to it below when setting EnableOptProf to true in build.yml.
 #   displayName: Skip OptProf optimization
 #   type: boolean
@@ -43,12 +43,8 @@ parameters:
   displayName: Run tests
   type: boolean
   default: true
-- name: EnableCompliance
-  displayName: Run Compliance Tools
-  type: boolean
-  default: true
 - name: EnableAPIScan
-  displayName: Include APIScan with Compliance tools
+  displayName: Include APIScan with compliance tools
   type: boolean
   default: true
 
@@ -63,18 +59,22 @@ variables:
 - template: GlobalVariables.yml
 
 extends:
-  ${{ if parameters.EnableCompliance }}:
+  ${{ if or(parameters.ForceOfficialBuild, eq(variables['Build.Reason'],'Schedule')) }}:
     template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
     parameters:
       sdl:
         sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+        codeSignValidation:
+          enabled: true
+          break: true
+          additionalTargetsGlobPattern: -|Variables-*\*.ps1;-|APIScanInputs-*\**;-|test_symbols-*\**;-|MicroBuild\**
         policheck:
           enabled: true
           exclusionsFile: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
         suppression:
           suppressionFile: $(System.DefaultWorkingDirectory)\azure-pipelines\falsepositives.gdnsuppress
         sbom:
-          enabled: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }} # Disable the generation for SBOMs for artifacts in unsigned builds since it's slow
+          enabled: true
       stages:
       - stage: Build
         variables:
@@ -83,9 +83,9 @@ extends:
         - template: /azure-pipelines/build.yml@self
           parameters:
             Is1ESPT: true
-            RealSign: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }}
+            RealSign: true
             # ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
-            EnableAPIScan: ${{ and(parameters.EnableCompliance, parameters.EnableAPIScan, ne(variables['Build.Reason'], 'pullRequest')) }}
+            EnableAPIScan: ${{ and(parameters.EnableAPIScan, ne(variables['Build.Reason'], 'pullRequest')) }}
             windowsPool: VSEngSS-MicroBuild2022-1ES
             linuxPool:
               name: AzurePipelines-EO
@@ -100,7 +100,7 @@ extends:
             RunTests: ${{ parameters.RunTests }}
       - template: /azure-pipelines/prepare-insertion-stages.yml@self
         parameters:
-          RealSign: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }}
+          RealSign: true
   ${{ else }}:
     template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
     parameters:
@@ -116,9 +116,9 @@ extends:
         - template: /azure-pipelines/build.yml@self
           parameters:
             Is1ESPT: true
-            RealSign: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }}
+            RealSign: false
             # ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
-            EnableAPIScan: ${{ and(parameters.EnableCompliance, parameters.EnableAPIScan, ne(variables['Build.Reason'], 'pullRequest')) }}
+            EnableAPIScan: false
             windowsPool: VSEngSS-MicroBuild2022-1ES
             linuxPool:
               name: AzurePipelines-EO
@@ -133,4 +133,4 @@ extends:
             RunTests: ${{ parameters.RunTests }}
       - template: /azure-pipelines/prepare-insertion-stages.yml@self
         parameters:
-          RealSign: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }}
+          RealSign: false

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -61,3 +61,7 @@ stages:
       - download: current
         artifact: deployables-Windows
         displayName: 🔻 Download deployables-Windows artifact
+      - template: WIFtoPATauth.yml
+        parameters:
+          wifServiceConnectionName: azure-public/vside package push
+          deadPATServiceConnectionId: 207efd62-fd0f-43e7-aeae-17c4febcc660 # azure-public/vs-impl

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -64,4 +64,4 @@ stages:
       - template: WIFtoPATauth.yml
         parameters:
           wifServiceConnectionName: azure-public/vside package push
-          deadPATServiceConnectionId: 207efd62-fd0f-43e7-aeae-17c4febcc660 # azure-public/vs-impl
+          deadPATServiceConnectionId: 42175e93-c771-4a4f-a132-3cca78f44b3b # azure-public/vssdk

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -57,6 +57,7 @@ extends:
             InsertionReviewers: $(Build.RequestedFor),Andrew Arnott
             AutoCompletePR: true
             AutoCompleteMergeStrategy: Squash
+            ShallowClone: true
         - powershell: |
             $contentType = 'application/json';
             $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -80,6 +80,7 @@ extends:
             InsertionBuildPolicy: Request Perf DDRITs
             InsertionReviewers: $(Build.RequestedFor)
             AutoCompletePR: false
+            ShallowClone: true
         - powershell: |
             $insertionPRId = azure-pipelines/Get-InsertionPRId.ps1
             $Markdown = @"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.201",
+    "version": "8.0.300",
     "rollForward": "patch",
     "allowPrerelease": false
   }


### PR DESCRIPTION
- Fix empty optimization inputs drops
- Use spaces for xml config files
- Better logging on source code archival failure
- Bump .NET SDK to 8.0.300
- Merge test related dependency updates (#271)
- Bump dotnet-coverage from 17.11.0 to 17.11.3 (#272)
- Bump Nerdbank.GitVersioning to 3.6.139
- Bump nbgv to 3.6.139
- Enable ShallowClone for VSInsertion
- Ensure Expand-Template uses UTF-8 when replacing placeholders.
- Drop SourceLink package reference
- Remove WPF workarounds for bugs fixed years ago
- Enable codeSignValidation and exclude non-shipping files
- Consolidate official build and real sign switches
- Switch from PAT-based to WIF-based auth
