### PR TITLE
Add `Verify.Operation` overloads that only load the string resource on failures

### DIFF
--- a/src/Microsoft.VisualStudio.Validation/Verify.cs
+++ b/src/Microsoft.VisualStudio.Validation/Verify.cs
@@ -3,6 +3,8 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -70,6 +72,70 @@ public static partial class Verify
         if (!condition)
         {
             throw new InvalidOperationException(message.ToStringAndClear());
+        }
+    }
+
+    /// <inheritdoc cref="Operation(bool, ResourceManager, string, object?)"/>
+    /// <param name="condition"><inheritdoc cref="Operation(bool, ResourceManager, string, object?[])" path="/param[@name='condition']"/></param>
+    /// <param name="resourceManager"><inheritdoc cref="Operation(bool, ResourceManager, string, object?[])" path="/param[@name='resourceManager']"/></param>
+    /// <param name="resourceName"><inheritdoc cref="Operation(bool, ResourceManager, string, object?[])" path="/param[@name='unformattedMessageResourceName']"/></param>
+    [DebuggerStepThrough]
+    public static void Operation([DoesNotReturnIf(false)] bool condition, ResourceManager resourceManager, string resourceName)
+    {
+        Requires.NotNull(resourceManager, nameof(resourceManager));
+        if (!condition)
+        {
+            throw new InvalidOperationException(resourceManager.GetString(resourceName, CultureInfo.CurrentCulture));
+        }
+    }
+
+    /// <inheritdoc cref="Operation(bool, ResourceManager, string, object?, object?)"/>
+    [DebuggerStepThrough]
+    public static void Operation([DoesNotReturnIf(false)] bool condition, ResourceManager resourceManager, string unformattedMessageResourceName, object? arg1)
+    {
+        Requires.NotNull(resourceManager, nameof(resourceManager));
+        if (!condition)
+        {
+            throw new InvalidOperationException(PrivateErrorHelpers.Format(resourceManager.GetString(unformattedMessageResourceName, CultureInfo.CurrentCulture)!, arg1));
+        }
+    }
+
+    /// <inheritdoc cref="Operation(bool, ResourceManager, string, object?[])"/>
+    /// <param name="condition"><inheritdoc cref="Operation(bool, ResourceManager, string, object?[])" path="/param[@name='condition']"/></param>
+    /// <param name="resourceManager"><inheritdoc cref="Operation(bool, ResourceManager, string, object?[])" path="/param[@name='resourceManager']"/></param>
+    /// <param name="unformattedMessageResourceName"><inheritdoc cref="Operation(bool, ResourceManager, string, object?[])" path="/param[@name='unformattedMessageResourceName']"/></param>
+    /// <param name="arg1">The first formatting argument.</param>
+    /// <param name="arg2">The second formatting argument.</param>
+    [DebuggerStepThrough]
+    public static void Operation([DoesNotReturnIf(false)] bool condition, ResourceManager resourceManager, string unformattedMessageResourceName, object? arg1, object? arg2)
+    {
+        Requires.NotNull(resourceManager, nameof(resourceManager));
+        if (!condition)
+        {
+            throw new InvalidOperationException(PrivateErrorHelpers.Format(resourceManager.GetString(unformattedMessageResourceName, CultureInfo.CurrentCulture)!, arg1, arg2));
+        }
+    }
+
+    /// <summary>
+    /// Throws an <see cref="InvalidOperationException"/> if a condition is false.
+    /// </summary>
+    /// <param name="condition">The condition to check.</param>
+    /// <param name="resourceManager">The resource manager from which to retrieve the exception message. For example: <c>Strings.ResourceManager</c>.</param>
+    /// <param name="unformattedMessageResourceName">The name of the string resource to obtain for the exception message. For example: <c>nameof(Strings.SomeError)</c>.</param>
+    /// <param name="args">The formatting arguments.</param>
+    /// <remarks>
+    /// This overload allows only loading a localized string in the error condition as an optimization in perf critical sections over the simpler
+    /// to use <see cref="Operation(bool, string?)"/> overload.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="resourceManager"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="condition"/> is <see langword="false"/>.</exception>
+    [DebuggerStepThrough]
+    public static void Operation([DoesNotReturnIf(false)] bool condition, ResourceManager resourceManager, string unformattedMessageResourceName, params object?[] args)
+    {
+        Requires.NotNull(resourceManager, nameof(resourceManager));
+        if (!condition)
+        {
+            throw new InvalidOperationException(PrivateErrorHelpers.Format(resourceManager.GetString(unformattedMessageResourceName, CultureInfo.CurrentCulture)!, args));
         }
     }
 

--- a/test/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
+++ b/test/Microsoft.VisualStudio.Validation.Tests/VerifyTests.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.InteropServices;
 using Microsoft;
+using Microsoft.VisualStudio.Validation.Tests;
 using Xunit;
 
 public class VerifyTests
@@ -37,6 +38,23 @@ public class VerifyTests
         InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => Verify.Operation(false, $"Some {FormattingMethod()} method."));
         Assert.Equal(1, formatCount);
         Assert.StartsWith("Some generated string method.", ex.Message);
+    }
+
+    [Fact]
+    public void Operation_ResourceManager()
+    {
+        AssertThrows(TestStrings.GetResourceString(TestStrings.SomeError), c => Verify.Operation(c, TestStrings.ResourceManager, TestStrings.SomeError));
+        AssertThrows(TestStrings.FormatSomeError1Arg("A"), c => Verify.Operation(c, TestStrings.ResourceManager, TestStrings.SomeError1Arg, "A"));
+        AssertThrows(TestStrings.FormatSomeError2Args("A", "B"), c => Verify.Operation(c, TestStrings.ResourceManager, TestStrings.SomeError2Args, "A", "B"));
+        AssertThrows(TestStrings.FormatSomeError3Args("A", "B", "C"), c => Verify.Operation(c, TestStrings.ResourceManager, TestStrings.SomeError3Args, "A", "B", "C"));
+
+        static void AssertThrows(string? expectedMessage, Action<bool> action)
+        {
+            action(true);
+
+            InvalidOperationException actual = Assert.Throws<InvalidOperationException>(() => action(false));
+            Assert.Equal(expectedMessage, actual.Message);
+        }
     }
 
     [Fact]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.8",
+  "version": "17.12-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
This pattern is already offered from the `Requires` class.

Also bump the version to reflect added API.